### PR TITLE
ClientThread and other additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,133 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# IDE's craps
+.idea/
+.vscode/

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,2 @@
 from .scoreunlocked_client import *
+from .client_thread import ClientThread

--- a/src/client_thread.py
+++ b/src/client_thread.py
@@ -1,0 +1,103 @@
+import threading
+
+from .scoreunlocked_client import Client
+from typing import Union
+
+
+class ClientThread(threading.Thread):
+
+    """
+    This thread is useful to have a constantly updated leaderboard, without constantly pausing the program.
+    Also, the post requests won't pause the program too.
+    As the requests take time, you'll though have to wait about ~2 seconds after a post request to see it appear in the
+    leaderboard.
+
+    It is a daemon thread, so you don't have to worry on closing it when stopping your program, as it will be stopped
+    if all the non-daemon threads stop (in your case, your main thread).
+
+    Its usage is the same as a normal client, simply the get and post method don't pause your program.
+    """
+
+    def __init__(self,
+                 timeout: float = 5.0,
+                 parse_json: bool = True,
+                 endpoint: str = 'https://scoreunlocked.pythonanywhere.com',
+                 raise_errors: bool = False
+                 ) -> None:
+        # init the Thread class
+        super().__init__()
+
+        # init the client
+        self.client = Client(timeout=timeout, parse_json=parse_json, endpoint=endpoint, raise_errors=raise_errors)
+
+        # Thread states
+        self.running = True  # the thread is running
+        self.daemon = True  # the thread is a daemon-thread
+        self.connected = False  # the client is connected
+
+        # the updated leaderboard
+        self.current_leader_board = []
+        # the queue for posting new scores
+        self.score_to_post = []
+
+        # start the thread at initialization
+        self.start()
+
+    def connect(self, developer: str, leaderboard: str) -> None:
+        """
+        Connect the client to the server.
+        :param developer: The name of the developer owning the leaderboard (str)
+        :param leaderboard: The name of the leaderboard (str)
+        :return: None
+        """
+        self.connected = True
+        self.client.connect(developer=developer, leaderboard=leaderboard)
+
+    def disconnect(self) -> None:
+        """
+        Exit the thread, and therefore delete the client.
+        :return: None
+        """
+        self.running = False
+        del self.client
+
+    def update_leaderboard(self) -> None:
+        """
+        Updates the leaderboard.
+        :return: None
+        """
+        self.current_leader_board = self.client.get_leaderboard()
+
+    def get_leaderboard(self) -> list:
+        """
+        Get the updated leaderboard.
+        :return: The leaderboard (list)
+        """
+        return self.current_leader_board
+
+    def post_score(self, name: str, score: Union[int, float], validation_data='') -> None:
+        """
+        Append a new score to the post queue.
+        :param name: Name of the user (str)
+        :param score: Posted score (int or float if float is enabled in the leaderboard settings)
+        :param validation_data: ? (str)
+        :return: None
+        """
+        self.score_to_post.append([name, score, validation_data])
+
+    def run(self) -> None:
+        """
+        The main loop of the Thread.
+        :return: None
+        """
+
+        while self.running:
+
+            if self.connected:
+                # if the client is connected, update the leaderboard
+                self.update_leaderboard()
+
+                # post every score present in the queue, and then empty it
+                for score in self.score_to_post:
+                    self.client.post_score(*score)
+                self.score_to_post = []

--- a/src/scoreunlocked_client.py
+++ b/src/scoreunlocked_client.py
@@ -102,18 +102,19 @@ class Client:
             print(f'An Error Occurred: {e}')
             return None
 
+    def start_post_thread(self, name, score, validation_data='') -> None:
+        posting_thread = threading.Thread(target=self.post_score, args=(name, score, validation_data, False))
+        return posting_thread.start()
+
     def post_score(self, name, score, validation_data='', use_thread=True):
-        if use_thread:
-            # if the user choses to use thread then, create a new thread, with as target the same function called
-            # but without using thread itself, so it doesn't create an infinite thread recursion
-            posting_thread = threading.Thread(target=self.post_score, args=(name, score, validation_data, False))
-            return posting_thread.start()
 
         if self.raise_errors:
-            return self._post_score(name, score, validation_data)
+            return self.start_post_thread(name, score, validation_data) if use_thread \
+                else self._post_score(name, score, validation_data)
         else:
             try:
-                return self._post_score(name, score, validation_data)
+                return self.start_post_thread(name, score, validation_data) if use_thread \
+                    else self._post_score(name, score, validation_data)
             except requests.ReadTimeout:
                 return None
             except Exception as e:

--- a/src/scoreunlocked_client.py
+++ b/src/scoreunlocked_client.py
@@ -1,5 +1,5 @@
 import json
-
+import threading
 import requests
 
 
@@ -102,7 +102,13 @@ class Client:
             print(f'An Error Occurred: {e}')
             return None
 
-    def post_score(self, name, score, validation_data=''):
+    def post_score(self, name, score, validation_data='', use_thread=True):
+        if use_thread:
+            # if the user choses to use thread then, create a new thread, with as target the same function called
+            # but without using thread itself, so it doesn't create an infinite thread recursion
+            posting_thread = threading.Thread(target=self.post_score, args=(name, score, validation_data, False))
+            return posting_thread.start()
+
         if self.raise_errors:
             return self._post_score(name, score, validation_data)
         else:

--- a/src/scoreunlocked_client.py
+++ b/src/scoreunlocked_client.py
@@ -102,19 +102,12 @@ class Client:
             print(f'An Error Occurred: {e}')
             return None
 
-    def start_post_thread(self, name, score, validation_data='') -> None:
-        posting_thread = threading.Thread(target=self.post_score, args=(name, score, validation_data, False))
-        return posting_thread.start()
-
-    def post_score(self, name, score, validation_data='', use_thread=True):
-
+    def post_score(self, name, score, validation_data=''):
         if self.raise_errors:
-            return self.start_post_thread(name, score, validation_data) if use_thread \
-                else self._post_score(name, score, validation_data)
+            return self._post_score(name, score, validation_data)
         else:
             try:
-                return self.start_post_thread(name, score, validation_data) if use_thread \
-                    else self._post_score(name, score, validation_data)
+                return self._post_score(name, score, validation_data)
             except requests.ReadTimeout:
                 return None
             except Exception as e:

--- a/src/scoreunlocked_client.py
+++ b/src/scoreunlocked_client.py
@@ -1,5 +1,4 @@
 import json
-import threading
 import requests
 
 

--- a/test_script.py
+++ b/test_script.py
@@ -13,7 +13,7 @@ import random
 
 
 # connect the client
-client = scoreunlocked.Client()
+client = scoreunlocked.ClientThread()
 client.connect("fks124-dev", "test")
 
 # initialize pygame stuff
@@ -32,7 +32,7 @@ while True:
             # post a new random score
             if event.key == pg.K_p:
                 # this one works without pausing the program
-                client.post_score(name="dev", score=random.randint(0, 100))
+                client.post_score(name="dev2", score=random.randint(0, 100))
 
                 # this one does pause the program
                 # client.post_score(name="dev", score=random.randint(0, 100), use_thread=False)

--- a/test_script.py
+++ b/test_script.py
@@ -1,0 +1,47 @@
+"""
+Test file for the new patches
+
+Created by @fkS124 - 07/29/22 18:06:36
+
+This file should be deleted at the end of the development phase.
+"""
+
+
+import src as scoreunlocked
+import pygame as pg
+import random
+
+
+# connect the client
+client = scoreunlocked.Client()
+client.connect("fks124-dev", "test")
+
+# initialize pygame stuff
+pg.init()
+screen = pg.display.set_mode((300, 300))
+clock = pg.time.Clock()
+
+while True:
+
+    for event in pg.event.get():
+        if event.type == pg.QUIT:
+            pg.quit()
+            raise SystemExit
+
+        if event.type == pg.KEYDOWN:
+            # post a new random score
+            if event.key == pg.K_p:
+                # this one works without pausing the program
+                client.post_score(name="dev", score=random.randint(0, 100))
+
+                # this one does pause the program
+                # client.post_score(name="dev", score=random.randint(0, 100), use_thread=False)
+
+            # get the current leaderboard
+            elif event.key == pg.K_s:
+                print(client.get_leaderboard())
+
+    screen.fill((random.randint(0, 255), 0, 0))
+    pg.display.update()
+    clock.tick(60)
+    pg.display.set_caption(str(clock.get_fps()))


### PR DESCRIPTION
- Added the `ClientThread` object. It's a thread running constantly in the background, that permits to post scores and get the leaderboard without pausing the main thread (i.e your game loop). Its usage is the same as a normal `Client`, and you'll find more information in its [documentation](https://github.com/tank-king/scoreunlocked/compare/main...fkS124:scoreunlocked:main#diff-a199558ce506f28b167c2a307b1cd1042c7339d4002750f04d60f155d6255ec6)
- Added a .gitignore using a python generic template.
- Added a test script for development purposes.